### PR TITLE
Dynamic user profile page added

### DIFF
--- a/app/profile/[id]/page.jsx
+++ b/app/profile/[id]/page.jsx
@@ -1,0 +1,36 @@
+"use client";
+
+import React, { useState, useEffect } from "react";
+import { useSearchParams } from "next/navigation";
+
+import Profile from "@/components/Profile";
+
+const UserProfile = ({params}) => {
+  const searchParams = useSearchParams();
+
+  const userName = searchParams.get("name")
+
+  const [posts, setPosts] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchPosts = async () => {
+      const response = await fetch(`/api/users/${params?.id}/posts`);
+      const data = await response.json();
+      setPosts(data);
+      setLoading(false);
+    };
+
+    if (params?.id) fetchPosts();
+  }, []);
+
+  return (
+    <Profile
+      name={userName}
+      desc={`Welcome to ${!loading ? userName : ""} profile page. Explore ${userName}'s exceptional prompts and be inspired!`}
+      data={posts}
+    />
+  );
+};
+
+export default UserProfile;

--- a/components/Feed.jsx
+++ b/components/Feed.jsx
@@ -22,18 +22,16 @@ const Feed = () => {
   const [searchedResults, setSearchResults] = useState([]);
 
   const [posts, setPosts] = useState([]);
-  const [allPosts, setAllPosts] = useState([]);
 
   const fetchPosts = async () => {
     const response = await fetch("/api/prompt");
     const data = await response.json();
     setPosts(data);
-    setAllPosts(data);
   };
 
   const filterPrompts = (searchtext) => {
     const regex = new RegExp(searchtext, "i");
-    return allPosts.filter(
+    return posts.filter(
       (item) =>
         regex.test(item.creator.username) ||
         regex.test(item.tag) ||

--- a/components/Nav.jsx
+++ b/components/Nav.jsx
@@ -61,7 +61,7 @@ const Nav = () => {
               Object.values(providers).map((provider) => (
                   <button
                     type="button"
-                    key={providers.id}
+                    key={provider.id}
                     onClick={() => signIn(provider.id)}
                     className="black_btn mr-3"
                   >

--- a/components/PromptCard.jsx
+++ b/components/PromptCard.jsx
@@ -17,10 +17,17 @@ const PromptCard = ({ post, handleTagClick, handleEdit, handleDelete }) => {
     setTimeout(() => setCopied(""), 3000);
   };
 
+  const handleProfileClick = () => {
+    if (post.creator._id === session?.user.id) return router.push("/profile");
+    router.push(`/profile/${post.creator._id}?name=${post.creator.username}`);
+  };
+
   return (
     <div className="prompt_card">
       <div className="flex justify-between items-start gap-5">
-        <div className="flex-1 flex justify-start items-center gap-3 cursor-pointer">
+        <div className="flex-1 flex justify-start items-center gap-3 cursor-pointer"
+        onClick={handleProfileClick}
+        >
           <Image
             src={post.creator?.image}
             alt="user_image"


### PR DESCRIPTION
**Task:**
To create a user profile page which users can go to by clicking on the posts.

** Why:**
Have one page which can view all of the creator's posts.

**How:**
Utilizing Next's navigation's 'useSearchParams', we can access the dynamic part of the URL route which gives the user's id.
This can be used to fetch all of the posts from that user and then display them on the page.

/profile/${post.creator._id}?name=${post.creator.username}